### PR TITLE
fix: correct Markmap Plus plugin id

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -184,7 +184,7 @@
     "platforms": ["win32", "linux", "darwin"]
   },
   {
-    "id": "typora-plugin-markmap-plus",
+    "id": "util6.markmapplus",
     "name": "Markmap Plus",
     "author": "util6",
     "description": "Use Markmap in Typora.",


### PR DESCRIPTION
Fix plugin id mismatch for Markmap Plus.

Current marketplace entry uses:
- `typora-plugin-markmap-plus`

But the published plugin manifest now uses:
- `util6.markmapplus`

This mismatch causes marketplace installation to fail with an id mismatch error.